### PR TITLE
Rounding per zoom level

### DIFF
--- a/rio_rgbify/mbtiler.py
+++ b/rio_rgbify/mbtiler.py
@@ -142,7 +142,11 @@ def _tile_worker(tile):
         resampling=Resampling.bilinear,
     )
 
-    out = data_to_rgb(out, global_args["encoding"], global_args["base_val"], global_args["interval"], global_args["round_digits"])
+    z_round_digits = global_args["round_digits"]
+    if isinstance(z_round_digits, list):
+        z_round_digits = z_round_digits[z - global_args["min_z"]]
+
+    out = data_to_rgb(out, global_args["encoding"], global_args["base_val"], global_args["interval"], z_round_digits)
 
     return tile, global_args["writer_func"](out, global_args["kwargs"].copy(), toaffine)
 
@@ -235,7 +239,7 @@ class RGBTiler:
     interval: float
         the interval at which to encode
         Default=1
-    round_digits: int
+    round_digits: int | [int]
         Erased less significant digits
         Default=0
     encoding: str
@@ -300,6 +304,8 @@ class RGBTiler:
             "base_val": base_val,
             "interval": interval,
             "round_digits": round_digits,
+            "min_z": min_z,
+            "max_z": max_z,
             "encoding": encoding,
             "writer_func": writer_func,
         }

--- a/rio_rgbify/scripts/cli.py
+++ b/rio_rgbify/scripts/cli.py
@@ -38,9 +38,9 @@ def _rgb_worker(data, window, ij, g_args):
 @click.option(
     "--round-digits",
     "-r",
-    type=int,
-    default=0,
-    help="Less significants encoded bits to be set to 0. Round the values, but have better images compression [DEFAULT=0]",
+    type=str,
+    default="0",
+    help="Less significants encoded bits to be set to 0. Round the values, but have better images compression. Use an array if you want to specify rounding digits from min to max zoom level  [DEFAULT=0]",
 )
 @click.option(
     "--encoding",
@@ -121,6 +121,19 @@ def rgbify(
             raise ValueError(
                 "Max zoom {0} must be greater than min zoom {1}".format(max_z, min_z)
             )
+
+        if round_digits is not None:
+            try:
+                round_digits = json.loads(round_digits)
+            except Exception:
+                raise TypeError(
+                    "Rounding digits of {0} is not valid".format(round_digits)
+                )
+            if isinstance(round_digits, list):
+                if len(round_digits) != max_z - min_z + 1:
+                    raise ValueError("Expected {0} rounding digits, got {1}".format(max_z - min_z + 1, len(round_digits)))
+            elif not round_digits.isnumeric():
+                "Rounding digits of {0} is not valid".format(round_digits)
 
         if bounding_tile is not None:
             try:


### PR DESCRIPTION
Many people are using the rounding approach described in the article by [Frédéric Rodrigo](https://medium.com/@frederic.rodrigo/optimization-of-rgb-dem-tiles-for-dynamic-hill-shading-with-mapbox-gl-or-maplibre-gl-55bef8eb3d86)

This is an attempt to integrate the idea into rgbify, making it super convenient:

`rio rgbify -r "[11,10,9,8,7,6,5,4]" --min-z 5 --max-z 12 --format webp source.tif dest.mbfiles`

Note: have not tested a whole lot yet.