### PR TITLE
Add missing scipy dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ rasterio~=1.0
 Pillow
 rio-mucho>=0.2.1
 mercantile
+scipy

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open("rio_rgbify/__init__.py") as f:
 long_description = """"""
 
 # Runtime requirements.
-inst_reqs = ["click", "rasterio~=1.0", "rio-mucho", "Pillow", "mercantile"]
+inst_reqs = ["click", "rasterio~=1.0", "rio-mucho", "Pillow", "mercantile", "scipy"]
 
 extra_reqs = {
     "test": ["pytest", "pytest-cov", "codecov", "hypothesis", "raster_tester"],


### PR DESCRIPTION
As I started with a clean python environment I noticed that scipy isn't defined as a dependency.